### PR TITLE
Initialize agentic AI training scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Agentic AI Training Repository
+
+This repository provides a structured environment for students to explore agentic behaviors in modern generative AI systems. The primary learning resources are a curated set of Jupyter notebooks supported by lightweight datasets and scripts.
+
+## Repository Layout
+
+```
+notebooks/
+  01_introduction.ipynb           # Overview of goals and environment checks
+  02_function_calling_basics.ipynb # Function calling workflows and mock tooling
+  03_model_context_protocol.ipynb # Sharing context through the Model Context Protocol
+  04_agent_to_agent_protocol.ipynb # Collaboration patterns between agents
+
+data/
+  agent_sessions.csv              # Sample transcript fragments for analysis exercises
+
+scripts/
+  generate_mock_data.py           # Utility for creating additional mock session data
+```
+
+## Getting Started
+
+1. Launch your preferred Jupyter environment (e.g., VS Code, JupyterLab, or `jupyter notebook`).
+2. Begin with `notebooks/01_introduction.ipynb` and work through the sequence.
+3. Use the CSV data and helper script as optional extensions for hands-on experiments.
+
+## Extending the Materials
+
+- Add new notebooks to cover advanced scenarios such as tool orchestration or evaluation pipelines.
+- Capture real or simulated agent transcripts in the `data/` directory to ground the exercises.
+- Enhance `generate_mock_data.py` with richer sampling strategies or integrations with external APIs.
+
+Contributions and iterations are encouraged to adapt the curriculum to different classroom settings.

--- a/data/agent_sessions.csv
+++ b/data/agent_sessions.csv
@@ -1,0 +1,5 @@
+session_id,role,message_type,content
+S1,planner,system,Establishing project goals
+S1,researcher,tool_call,Searching academic database for references
+S1,writer,response,Outlined initial summary draft
+S2,evaluator,feedback,Clarify constraints on resource usage

--- a/data/extended_agent_sessions.csv
+++ b/data/extended_agent_sessions.csv
@@ -1,0 +1,4 @@
+session_id,role,message_type,content,timestamp
+S3,planner,instruction,Define analysis tasks,2025-09-28T18:34:16.823498+00:00
+S3,analyst,tool_call,query:extract_entities,2025-09-28T18:34:16.823498+00:00
+S3,writer,draft,Summarize extracted entities,2025-09-28T18:34:16.823498+00:00

--- a/notebooks/01_introduction.ipynb
+++ b/notebooks/01_introduction.ipynb
@@ -1,0 +1,53 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Welcome to Agentic AI Training\n",
+    "\n",
+    "This notebook introduces the repository and the training objectives."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Learning Goals\n",
+    "- Understand the scope of the training curriculum.\n",
+    "- Get familiar with the supporting assets.\n",
+    "- Run a quick environment check."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!python --version"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Next Steps\n",
+    "Continue to the next notebook to explore function calling workflows."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/02_function_calling_basics.ipynb
+++ b/notebooks/02_function_calling_basics.ipynb
@@ -1,0 +1,58 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Function Calling Basics\n",
+    "\n",
+    "Learn how language models can decide when to invoke tools."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Concept Overview\n",
+    "- Motivation for structured tool execution.\n",
+    "- Anatomy of a function call payload.\n",
+    "- Error handling patterns."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: Implement a mock function call handler\n",
+    "def call_tool(tool_name, **kwargs):\n",
+    "    \"\"\"Return a fake response for training purposes.\"\"\"\n",
+    "    return {\"tool\": tool_name, \"arguments\": kwargs, \"status\": \"ok\"}\n",
+    "\n",
+    "call_tool('search_documents', query='agent toolkits', top_k=3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Practice\n",
+    "Experiment with the `call_tool` function and adapt it to reflect your own tool signatures."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/03_model_context_protocol.ipynb
+++ b/notebooks/03_model_context_protocol.ipynb
@@ -1,0 +1,63 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Model Context Protocol (MCP)\n",
+    "\n",
+    "Investigate how agents standardize context sharing across tools and peers."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Reference Frames\n",
+    "- Session metadata.\n",
+    "- Resource handles.\n",
+    "- Continuation tokens."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Sample skeleton for an MCP message\n",
+    "model_context_message = {\n",
+    "    'type': 'resource_request',\n",
+    "    'resource': 'vector_store',\n",
+    "    'constraints': {\n",
+    "        'namespace': 'project-alpha',\n",
+    "        'limit': 5\n",
+    "    }\n",
+    "}\n",
+    "model_context_message"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Discussion Prompts\n",
+    "1. How do you validate that the agent respects namespace boundaries?\n",
+    "2. What guardrails are needed for paginated resources?"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/04_agent_to_agent_protocol.ipynb
+++ b/notebooks/04_agent_to_agent_protocol.ipynb
@@ -1,0 +1,63 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Agent-to-Agent Protocols\n",
+    "\n",
+    "Explore how multiple agents coordinate tasks and share artifacts."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Communication Patterns\n",
+    "- Task delegation.\n",
+    "- Conflict resolution.\n",
+    "- Shared memory updates."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Sketch a conversation state shared between agents\n",
+    "conversation_state = {\n",
+    "    'task': 'draft project summary',\n",
+    "    'lead_agent': 'planner',\n",
+    "    'support_agents': ['researcher', 'writer'],\n",
+    "    'artifacts': [\n",
+    "        {'owner': 'researcher', 'type': 'link', 'value': 'https://example.com/report'},\n",
+    "        {'owner': 'writer', 'type': 'draft', 'value': 'Initial outline here.'}\n",
+    "    ]\n",
+    "}\n",
+    "conversation_state"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercises\n",
+    "Simulate a hand-off between the planner and writer agents and document the transition steps."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/scripts/generate_mock_data.py
+++ b/scripts/generate_mock_data.py
@@ -1,0 +1,31 @@
+"""Utility script to expand the training dataset for agent session transcripts."""
+from __future__ import annotations
+
+import csv
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Iterable, List
+
+
+def build_rows() -> Iterable[List[str]]:
+    """Return mock rows representing interactions between agents."""
+    timestamp = datetime.now(UTC).isoformat()
+    return [
+        ["S3", "planner", "instruction", "Define analysis tasks", timestamp],
+        ["S3", "analyst", "tool_call", "query:extract_entities", timestamp],
+        ["S3", "writer", "draft", "Summarize extracted entities", timestamp],
+    ]
+
+
+def write_rows(destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with destination.open("w", newline="") as fp:
+        writer = csv.writer(fp)
+        writer.writerow(["session_id", "role", "message_type", "content", "timestamp"])
+        writer.writerows(build_rows())
+
+
+if __name__ == "__main__":
+    output_path = Path(__file__).resolve().parents[1] / "data" / "extended_agent_sessions.csv"
+    write_rows(output_path)
+    print(f"Wrote mock data to {output_path}")


### PR DESCRIPTION
## Summary
- add introductory curriculum of Jupyter notebooks covering agentic AI topics
- seed supporting CSV datasets for transcript analysis exercises
- include a helper script for generating additional mock agent session data and document the repository layout

## Testing
- python scripts/generate_mock_data.py

------
https://chatgpt.com/codex/tasks/task_b_68d97f2c7a60832da08603ea902a4965