### PR TITLE
Add OpenAI token setup to training materials

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ scripts/
 
 ## Getting Started
 
-1. Launch your preferred Jupyter environment (e.g., VS Code, JupyterLab, or `jupyter notebook`).
-2. Begin with `notebooks/01_introduction.ipynb` and work through the sequence.
-3. Use the CSV data and helper script as optional extensions for hands-on experiments.
+1. Export your OpenAI API token as `OPENAI_API_KEY` (or have it ready to provide when prompted).
+2. Launch your preferred Jupyter environment (e.g., VS Code, JupyterLab, or `jupyter notebook`).
+3. Begin with `notebooks/01_introduction.ipynb` and work through the sequence.
+4. Use the CSV data and helper script as optional extensions for hands-on experiments.
 
 ## Extending the Materials
 

--- a/notebooks/01_introduction.ipynb
+++ b/notebooks/01_introduction.ipynb
@@ -25,6 +25,32 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
+    "from getpass import getpass\n",
+    "\n",
+    "def _load_openai_api_key() -> str:\n",
+    "    \"\"\"Return an OpenAI API token, prompting the user if necessary.\"\"\"\n",
+    "    token = os.getenv(\"OPENAI_API_KEY\")\n",
+    "    if token:\n",
+    "        print(\"Using OpenAI API key from environment.\")\n",
+    "        return token\n",
+    "\n",
+    "    token = getpass(\"Enter your OpenAI API key: \")\n",
+    "    if not token:\n",
+    "        raise ValueError(\"An OpenAI API key is required to run this notebook.\")\n",
+    "    os.environ[\"OPENAI_API_KEY\"] = token\n",
+    "    print(\"Stored OpenAI API key in environment for this session.\")\n",
+    "    return token\n",
+    "\n",
+    "OPENAI_API_KEY = _load_openai_api_key()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "!python --version"
    ]
   },

--- a/notebooks/02_function_calling_basics.ipynb
+++ b/notebooks/02_function_calling_basics.ipynb
@@ -25,6 +25,32 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
+    "from getpass import getpass\n",
+    "\n",
+    "def _load_openai_api_key() -> str:\n",
+    "    \"\"\"Return an OpenAI API token, prompting the user if necessary.\"\"\"\n",
+    "    token = os.getenv(\"OPENAI_API_KEY\")\n",
+    "    if token:\n",
+    "        print(\"Using OpenAI API key from environment.\")\n",
+    "        return token\n",
+    "\n",
+    "    token = getpass(\"Enter your OpenAI API key: \")\n",
+    "    if not token:\n",
+    "        raise ValueError(\"An OpenAI API key is required to run this notebook.\")\n",
+    "    os.environ[\"OPENAI_API_KEY\"] = token\n",
+    "    print(\"Stored OpenAI API key in environment for this session.\")\n",
+    "    return token\n",
+    "\n",
+    "OPENAI_API_KEY = _load_openai_api_key()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# TODO: Implement a mock function call handler\n",
     "def call_tool(tool_name, **kwargs):\n",
     "    \"\"\"Return a fake response for training purposes.\"\"\"\n",

--- a/notebooks/03_model_context_protocol.ipynb
+++ b/notebooks/03_model_context_protocol.ipynb
@@ -25,6 +25,32 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
+    "from getpass import getpass\n",
+    "\n",
+    "def _load_openai_api_key() -> str:\n",
+    "    \"\"\"Return an OpenAI API token, prompting the user if necessary.\"\"\"\n",
+    "    token = os.getenv(\"OPENAI_API_KEY\")\n",
+    "    if token:\n",
+    "        print(\"Using OpenAI API key from environment.\")\n",
+    "        return token\n",
+    "\n",
+    "    token = getpass(\"Enter your OpenAI API key: \")\n",
+    "    if not token:\n",
+    "        raise ValueError(\"An OpenAI API key is required to run this notebook.\")\n",
+    "    os.environ[\"OPENAI_API_KEY\"] = token\n",
+    "    print(\"Stored OpenAI API key in environment for this session.\")\n",
+    "    return token\n",
+    "\n",
+    "OPENAI_API_KEY = _load_openai_api_key()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Sample skeleton for an MCP message\n",
     "model_context_message = {\n",
     "    'type': 'resource_request',\n",

--- a/notebooks/04_agent_to_agent_protocol.ipynb
+++ b/notebooks/04_agent_to_agent_protocol.ipynb
@@ -25,6 +25,32 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
+    "from getpass import getpass\n",
+    "\n",
+    "def _load_openai_api_key() -> str:\n",
+    "    \"\"\"Return an OpenAI API token, prompting the user if necessary.\"\"\"\n",
+    "    token = os.getenv(\"OPENAI_API_KEY\")\n",
+    "    if token:\n",
+    "        print(\"Using OpenAI API key from environment.\")\n",
+    "        return token\n",
+    "\n",
+    "    token = getpass(\"Enter your OpenAI API key: \")\n",
+    "    if not token:\n",
+    "        raise ValueError(\"An OpenAI API key is required to run this notebook.\")\n",
+    "    os.environ[\"OPENAI_API_KEY\"] = token\n",
+    "    print(\"Stored OpenAI API key in environment for this session.\")\n",
+    "    return token\n",
+    "\n",
+    "OPENAI_API_KEY = _load_openai_api_key()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Sketch a conversation state shared between agents\n",
     "conversation_state = {\n",
     "    'task': 'draft project summary',\n",

--- a/scripts/generate_mock_data.py
+++ b/scripts/generate_mock_data.py
@@ -1,10 +1,31 @@
 """Utility script to expand the training dataset for agent session transcripts."""
 from __future__ import annotations
 
+import argparse
 import csv
+import os
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Iterable, List
+
+
+def ensure_openai_token(token: str | None) -> str:
+    """Ensure an OpenAI API token is available for downstream integrations.
+
+    The script itself does not currently call the OpenAI API, but we enforce token
+    availability so that extending it with API calls is frictionless.
+    """
+
+    token = token or os.getenv("OPENAI_API_KEY")
+    if not token:
+        raise SystemExit(
+            "An OpenAI API token is required. Provide it via --openai-api-key or set "
+            "the OPENAI_API_KEY environment variable."
+        )
+
+    # Normalise environment so subsequent imports can rely on OPENAI_API_KEY.
+    os.environ.setdefault("OPENAI_API_KEY", token)
+    return token
 
 
 def build_rows() -> Iterable[List[str]]:
@@ -26,6 +47,15 @@ def write_rows(destination: Path) -> None:
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--openai-api-key",
+        dest="openai_api_key",
+        help="OpenAI API token. Falls back to the OPENAI_API_KEY environment variable.",
+    )
+    args = parser.parse_args()
+
+    ensure_openai_token(args.openai_api_key)
     output_path = Path(__file__).resolve().parents[1] / "data" / "extended_agent_sessions.csv"
     write_rows(output_path)
     print(f"Wrote mock data to {output_path}")


### PR DESCRIPTION
## Summary
- require an OpenAI API token for the mock data generator, accepting a CLI flag or environment variable
- add a reusable notebook cell that prompts for the OpenAI token and stores it in the environment for the session
- document the repository-wide expectation to export `OPENAI_API_KEY` before running the materials

## Testing
- python scripts/generate_mock_data.py --openai-api-key test-token

------
https://chatgpt.com/codex/tasks/task_b_68d980f9d790832da3244b73f782df3a