### PR TITLE
Expand MCP training notebook

### DIFF
--- a/notebooks/03_model_context_protocol.ipynb
+++ b/notebooks/03_model_context_protocol.ipynb
@@ -1,89 +1,129 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Model Context Protocol (MCP)\n",
-    "\n",
-    "Investigate how agents standardize context sharing across tools and peers."
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "# Model Context Protocol (MCP)\n\nThis notebook is a beginner-friendly, practical walkthrough of the **Model Context Protocol (MCP)**. MCP is an emerging standard that helps language-model agents share context with tools, other agents, and users in a predictable way. If you are new to agent systems, do not worry\u2014by the end of this notebook you will understand the basic ideas and have working code examples that you can adapt for your own projects.\n\n> **What you will learn:**\n> * Why context sharing matters when building AI assistants.\n> * The key concepts that MCP introduces.\n> * How to structure MCP messages and validate them in Python.\n> * How to simulate a small MCP interaction that fetches resources safely."
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "## How to use this notebook\n\n1. Work through the sections in order. Each section builds on the previous one and introduces a single new idea.\n2. Read the explanations in the markdown cells first, then run the accompanying code cells.\n3. If you are brand new to Python, simply press `Shift + Enter` in each code cell to execute it. The cell outputs will appear right below the cell.\n4. When you see an **Exercise**, pause and think through the guiding question before looking at the provided answer or explanation."
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "## Learning objectives\n\nBy the end of this notebook you should be able to:\n\n- Explain what \"context\" means for an AI agent and why it must be standardized.\n- Describe the main building blocks of the Model Context Protocol: sessions, resources, and messages.\n- Read and write simple MCP-compliant messages in JSON.\n- Run and modify Python helper functions that validate and format MCP traffic.\n- Identify common safety and observability practices when exchanging context."
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "## Key vocabulary\n\n| Term | Friendly definition |\n| --- | --- |\n| **Agent** | A program (often powered by a language model) that can reason, plan, and call tools on your behalf. |\n| **Context** | All of the information the agent can currently \"see\": the user request, previous steps, tool results, and constraints. |\n| **Protocol** | A shared agreement on message formats and behavior so that independent components can cooperate. |\n| **Session** | A temporary container that groups the steps for a single user request or job. |\n| **Resource** | A structured piece of data that can be shared via MCP (files, database rows, embeddings, etc.). |\n| **Namespace** | A label that keeps related resources grouped together and prevents accidental cross-talk between projects. |"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "## Why do we need a model context protocol?\n\nImagine an AI assistant that can search documents, call APIs, and email summaries. Each tool speaks its own language. Without a protocol, the agent might:\n\n- Forget to tell the tool which project the request belongs to, leaking data across teams.\n- Request too many results and overload a service.\n- Lose track of how to resume a multi-page response when pagination is required.\n\nA **model context protocol** solves these issues by enforcing a predictable structure for every message:\n\n1. The agent describes **what** it wants (for example, \"Give me the latest incidents for project *alpha*\").\n2. It includes **metadata** such as the session identifier and continuation tokens for pagination.\n3. The receiving tool validates the request before executing it and returns structured results.\n\nThe rest of this notebook explores how MCP encodes that structure."
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "## MCP building blocks at a glance\n\nThe MCP specification is still evolving, but most implementations rely on a few universal pieces:\n\n1. **Session Handshake** \u2013 establishes who is speaking and what capabilities they have.\n2. **Context Messages** \u2013 JSON documents that describe requests (`resource_request`, `tool_call`, etc.) and responses (`resource_response`, `error`).\n3. **Reference Frames** \u2013 metadata bundles that provide the shared frame of reference for an interaction: the active namespace, available resources, and pagination hints.\n4. **Guardrails** \u2013 limits such as maximum page size, allowed namespaces, and rate limits that keep the system safe.\n\nWe will create small Python helpers that encode these ideas explicitly."
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": "from dataclasses import dataclass, field, asdict\nfrom typing import Any, Dict, List, Literal, Optional\nfrom pprint import pprint\nimport json\n\nMessageType = Literal[\n    \"session_init\",\n    \"resource_request\",\n    \"resource_response\",\n    \"tool_call\",\n    \"tool_result\",\n    \"error\",\n]\n\n@dataclass\nclass ReferenceFrame:\n    \"\"\"Minimal description of a reference frame in MCP.\"\"\"\n\n    session_id: str\n    namespace: str\n    continuation_token: Optional[str] = None\n    resource_handles: List[str] = field(default_factory=list)\n\n@dataclass\nclass MCPMessage:\n    \"\"\"A convenience wrapper for MCP messages.\n\n    In practice the MCP spec uses JSON objects. We use a dataclass here to\n    make it easier to construct and validate messages in Python.\n    \"\"\"\n\n    type: MessageType\n    frame: ReferenceFrame\n    payload: Dict[str, Any] = field(default_factory=dict)\n    constraints: Dict[str, Any] = field(default_factory=dict)\n\n    def to_json(self) -> str:\n        \"\"\"Serialize the message to a JSON string.\"\"\"\n        return json.dumps(asdict(self), indent=2, sort_keys=True)\n\n    def validate(self) -> None:\n        \"\"\"Perform simple validation checks and raise ValueError if invalid.\"\"\"\n        if not self.frame.session_id:\n            raise ValueError(\"session_id must not be empty\")\n        if not self.frame.namespace:\n            raise ValueError(\"namespace must not be empty\")\n        if self.type == \"resource_request\" and \"resource\" not in self.payload:\n            raise ValueError(\"resource_request payload must include a 'resource' field\")\n        if self.type == \"resource_response\" and \"items\" not in self.payload:\n            raise ValueError(\"resource_response payload must include an 'items' list\")\n\n        limit = self.constraints.get(\"limit\")\n        if limit is not None and (not isinstance(limit, int) or limit <= 0):\n            raise ValueError(\"constraints.limit must be a positive integer\")\n        if limit is not None and limit > 100:\n            raise ValueError(\"constraints.limit is too high; cap at 100 per MCP best practice\")\n\n    def describe(self) -> None:\n        \"\"\"Print a human-readable summary for teaching purposes.\"\"\"\n        print(f\"Message type: {self.type}\")\n        print(f\"Session: {self.frame.session_id} | Namespace: {self.frame.namespace}\")\n        if self.frame.continuation_token:\n            print(f\"Continuation token: {self.frame.continuation_token}\")\n        if self.frame.resource_handles:\n            print(f\"Resource handles: {', '.join(self.frame.resource_handles)}\")\n        if self.constraints:\n            print(f\"Constraints: {self.constraints}\")\n        if self.payload:\n            print(\"Payload content:\")\n            pprint(self.payload)\n\ndef make_reference_frame(namespace: str, session_id: str = \"session-001\") -> ReferenceFrame:\n    return ReferenceFrame(session_id=session_id, namespace=namespace)\n"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "### Step 1 \u2013 Constructing a session handshake\n\nEvery interaction begins with a handshake that confirms the session and negotiates capabilities. In this simplified example we describe:\n\n- Which namespace the agent plans to access.\n- Which resources it already has handles for (maybe from previous steps).\n- Optional continuation tokens if the session is resuming a longer exchange.\n\nThe `describe()` helper prints the message in plain English, while `to_json()` shows the exact payload that would be sent over the wire."
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": "handshake = MCPMessage(\n    type=\"session_init\",\n    frame=make_reference_frame(namespace=\"project-alpha\"),\n    payload={\n        \"agent_capabilities\": [\"vector_search\", \"incident_reporting\"],\n        \"requested_tools\": [\"vector_store\"],\n    },\n)\n\nhandshake.validate()\nhandshake.describe()\nprint(\"\\nRaw JSON message:\\n\", handshake.to_json())\n"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "### Step 2 \u2013 Requesting a resource with guardrails\n\nAfter the handshake, the agent can issue a `resource_request`. MCP encourages explicit constraints so that tools can enforce safety limits. Common constraints include:\n\n- `limit`: the maximum number of items to return per page.\n- `filter`: key-value pairs the tool should use when narrowing results.\n- `sort`: instructions for ordering the response.\n\nThe example below asks the `vector_store` resource for the five most recent incident reports within the `project-alpha` namespace."
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": "resource_request = MCPMessage(\n    type=\"resource_request\",\n    frame=make_reference_frame(namespace=\"project-alpha\"),\n    payload={\n        \"resource\": \"vector_store\",\n        \"query\": \"recent incidents involving authentication\",\n    },\n    constraints={\n        \"limit\": 5,\n        \"sort\": {\"field\": \"timestamp\", \"order\": \"desc\"},\n    },\n)\n\nresource_request.validate()\nresource_request.describe()\nprint(\"\\nRaw JSON message:\\n\", resource_request.to_json())\n"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "### Step 3 \u2013 Simulating a tool response\n\nTo keep the notebook self-contained, we simulate a tool that receives the request and returns a matching `resource_response`. The response includes:\n\n- The same reference frame (session + namespace) so the agent can match replies.\n- A list of `items`, each with structured content.\n- A `continuation_token` when more pages are available.\n\nThe helper function `simulate_vector_store` illustrates how a tool might apply the incoming constraints. In a real MCP deployment the tool would perform a database query or API call instead of returning static data."
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": "from typing import Iterable\n\ndef simulate_vector_store(request: MCPMessage) -> MCPMessage:\n    \"\"\"Return a fake response to demonstrate MCP-compatible behavior.\"\"\"\n    request.validate()\n    fake_items = [\n        {\n            \"id\": \"incident-001\",\n            \"summary\": \"Authentication delays after rate limit misconfiguration.\",\n            \"timestamp\": \"2024-03-03T12:30:00Z\",\n        },\n        {\n            \"id\": \"incident-002\",\n            \"summary\": \"OAuth callback timeout affecting new sign-ups.\",\n            \"timestamp\": \"2024-02-27T09:15:00Z\",\n        },\n        {\n            \"id\": \"incident-003\",\n            \"summary\": \"Temporary credential leak detected and revoked.\",\n            \"timestamp\": \"2024-02-10T16:45:00Z\",\n        },\n    ]\n\n    limit = request.constraints.get(\"limit\", len(fake_items))\n    limited_items = fake_items[:limit]\n\n    continuation_token = None\n    if limit < len(fake_items):\n        continuation_token = \"next-page-token\"\n\n    response_frame = ReferenceFrame(\n        session_id=request.frame.session_id,\n        namespace=request.frame.namespace,\n        continuation_token=continuation_token,\n        resource_handles=[item[\"id\"] for item in limited_items],\n    )\n\n    response = MCPMessage(\n        type=\"resource_response\",\n        frame=response_frame,\n        payload={\"items\": limited_items},\n        constraints={\"limit\": limit},\n    )\n    response.validate()\n    return response\n\nresource_response = simulate_vector_store(resource_request)\nresource_response.describe()\nprint(\"\\nRaw JSON message:\\n\", resource_response.to_json())\n"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "### Step 4 \u2013 Continuing with pagination\n\nWhen the response provides a `continuation_token`, the agent can request the next page by reusing the token inside the reference frame. This keeps multi-page exchanges deterministic and prevents accidental duplication."
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": "next_page_request = MCPMessage(\n    type=\"resource_request\",\n    frame=ReferenceFrame(\n        session_id=resource_request.frame.session_id,\n        namespace=resource_request.frame.namespace,\n        continuation_token=resource_response.frame.continuation_token,\n    ),\n    payload={\"resource\": \"vector_store\", \"query\": \"recent incidents involving authentication\"},\n    constraints={\"limit\": 5},\n)\n\nnext_page_request.validate()\nnext_page_request.describe()\n"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "### Safety checklist\n\nBefore wiring MCP into production systems, run through this checklist:\n\n1. **Namespace enforcement:** Confirm that every tool checks the namespace in incoming frames and rejects mismatches.\n2. **Rate limiting:** Apply per-session rate limits to prevent abuse.\n3. **Pagination guardrails:** Require `limit` values and cap them to prevent expensive queries.\n4. **Audit logging:** Record the full JSON messages so that human operators can review what the agent requested and why.\n5. **Error handling:** Always send an explicit `error` message type when a request fails, including a human-readable description."
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "### Exercise \u2013 Create an error response\n\nAn MCP tool should send an `error` message if it cannot complete a request. Imagine that the `vector_store` tool receives a request for an unknown namespace. Sketch the structure of the error message before revealing the sample answer below."
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": "error_response = MCPMessage(\n    type=\"error\",\n    frame=make_reference_frame(namespace=\"project-unknown\"),\n    payload={\n        \"code\": \"namespace_not_found\",\n        \"message\": \"The namespace 'project-unknown' is not registered for this tool.\",\n        \"suggestion\": \"Verify the namespace or request access from the administrator.\",\n    },\n)\n\nerror_response.validate()\nerror_response.describe()\n"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "## Putting it all together\n\nThe flow below summarizes the mini-workflow you just implemented:\n\n1. **session_init** \u2192 agent introduces itself and negotiates capabilities.\n2. **resource_request** \u2192 agent asks for specific data with guardrails.\n3. **resource_response** \u2192 tool replies with structured items and optional continuation token.\n4. **resource_request (next page)** \u2192 agent continues paging until finished.\n5. **error** \u2192 tool uses explicit error messages to signal problems.\n\nBy structuring your traffic with MCP you gain reproducibility, observability, and safety\u2014all of which are essential for production-grade AI agents."
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "## Next steps\n\n- **Explore the official specification:** Search for the latest MCP reference documentation and compare the fields used there with the simplified version in this notebook.\n- **Integrate with your own tools:** Adapt the dataclasses to match the actual schema your platform expects and plug them into your agent's tool-calling logic.\n- **Add automated tests:** Use the `validate()` method from this notebook to build unit tests that reject malformed messages before they reach downstream services.\n- **Keep iterating:** Protocols evolve. Revisit your implementation regularly to incorporate new safety recommendations and capabilities.\n\nYou are now ready to move on to more advanced topics such as the Agent-to-Agent protocol or streaming resource updates."
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.10"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Reference Frames\n",
-    "- Session metadata.\n",
-    "- Resource handles.\n",
-    "- Continuation tokens."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "from getpass import getpass\n",
-    "\n",
-    "def _load_openai_api_key() -> str:\n",
-    "    \"\"\"Return an OpenAI API token, prompting the user if necessary.\"\"\"\n",
-    "    token = os.getenv(\"OPENAI_API_KEY\")\n",
-    "    if token:\n",
-    "        print(\"Using OpenAI API key from environment.\")\n",
-    "        return token\n",
-    "\n",
-    "    token = getpass(\"Enter your OpenAI API key: \")\n",
-    "    if not token:\n",
-    "        raise ValueError(\"An OpenAI API key is required to run this notebook.\")\n",
-    "    os.environ[\"OPENAI_API_KEY\"] = token\n",
-    "    print(\"Stored OpenAI API key in environment for this session.\")\n",
-    "    return token\n",
-    "\n",
-    "OPENAI_API_KEY = _load_openai_api_key()\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Sample skeleton for an MCP message\n",
-    "model_context_message = {\n",
-    "    'type': 'resource_request',\n",
-    "    'resource': 'vector_store',\n",
-    "    'constraints': {\n",
-    "        'namespace': 'project-alpha',\n",
-    "        'limit': 5\n",
-    "    }\n",
-    "}\n",
-    "model_context_message"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Discussion Prompts\n",
-    "1. How do you validate that the agent respects namespace boundaries?\n",
-    "2. What guardrails are needed for paginated resources?"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "name": "python",
-   "version": "3"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary
- expand the Model Context Protocol notebook into a beginner-friendly training guide with objectives and terminology
- add dataclass helpers and runnable MCP message examples that demonstrate requests, responses, and pagination
- document safety guardrails plus an error-handling exercise to reinforce best practices

## Testing
- python - <<'PY'
import json
from pathlib import Path

nb = json.loads(Path('notebooks/03_model_context_protocol.ipynb').read_text())
namespace = {}
for idx, cell in enumerate(nb['cells']):
    if cell['cell_type'] != 'code':
        continue
    code = cell['source']
    print(f"\n--- Executing cell {idx} ---")
    exec(compile(code, filename=f'cell_{idx}', mode='exec'), namespace)
PY

------
https://chatgpt.com/codex/tasks/task_b_68dba3265fbc832d81d33632fa33460e